### PR TITLE
Add MidoNet Insights Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,19 @@ Ansible playbooks for OpenStack + MidoNet
 
 * Run `scripts/install-ansible.sh` to install Ansible, dependencies and roles.
 
-* Run All-in-one playbook:
+* Run All-in-one playbook (MidoNet):
 
-    ansible-playbook -i localhost, -c local playbooks/allinone/midonet-allinone.yml
+```
+ansible-playbook -i localhost, -c local playbooks/allinone/midonet-allinone.yml
+````
+
+* Run All-in-one playbook (MEM):
+
+```
+export MEM_ENABLED=True MEM_USERNAME=repo_username MEM_PASSWORD=repo_password
+ansible-playbook -i localhost, -c local playbooks/allinone/midonet-allinone.yml
+````
+
 
 ### Openstack multi-node
 

--- a/playbooks/allinone/midonet-allinone.yml
+++ b/playbooks/allinone/midonet-allinone.yml
@@ -1,9 +1,16 @@
 ---
 
 - hosts: all
-  remote_user: root
   become: True
+
   pre_tasks:
+    - set_fact:
+        midonet_repo_mem_enabled: True
+        midonet_repo_mem_username: '{{ lookup("env", "MEM_USERNAME") }}'
+        midonet_repo_mem_password: '{{ lookup("env", "MEM_PASSWORD") }}'
+        midonet_cluster_mem_enabled: True
+        midonet_agent_mem_enabled: True
+      when: '{{ lookup("env", "MEM_ENABLED")|default(False) }}'
 
     - name: Install Ubuntu Cloud archive keyring (Debian)
       when: ansible_os_family == 'Debian'
@@ -29,6 +36,9 @@
         - policycoreutils-python
 
   roles:
+    - role: midonet-repos
+      openstack_version: 'mitaka'
+
     - role: mysql
       mysql_daemon: 'mysql'
       mysql_log_error: '/var/log/mysql/error.log'
@@ -52,8 +62,6 @@
         - openjdk-8-jdk
 
     - rabbitmq
-    - role: midonet-repos
-      openstack_version: 'mitaka'
     - role: zookeeper
     - role: cassandra
     - openstack-keystone
@@ -68,3 +76,9 @@
     - role: midonet-agent
       zookeeper_hosts: ['localhost']
     - midonet-gateway
+
+    - role: elasticsearch
+    - role: logstash
+
+    - role: midonet-insights-analytics
+      zookeeper_hosts: ['localhost']

--- a/requirements.yml
+++ b/requirements.yml
@@ -49,3 +49,12 @@
 
 - name: midonet-gateway
   src: https://github.com/midonet/ansible-midonet-gateway
+
+- name: 'elasticsearch'
+  src: 'https://github.com/midonet/ansible-elasticsearch'
+
+- name: 'logstash'
+  src: 'https://github.com/midonet/ansible-logstash'
+
+- name: 'midonet-insights-analytics'
+  src: 'https://github.com/midonet/ansible-midonet-insights-analytics'

--- a/roles/.gitignore
+++ b/roles/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Add MidoNet Insights Analytics role for All-in-One installer. Requires a
repository username and password to try out.

Signed-off-by: Ryo Tagami <rtagami@airstrip.jp>